### PR TITLE
Feedback, Variables, and better connection handling

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,3 +6,5 @@ This module sends a HTTP GET request to the router for control
 * Select a destination
 * Select a source
 * Perform router salvo (not tested!) 
+* Feedbacks for router destination/source changes
+* Variables for destinations

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -62,7 +62,6 @@ exports.initFeedbacks = function() {
 			}
 		],
 		callback: (feedback) => {
-			console.log(this.srcToDestMap)
 			return feedback.options.dest in this.srcToDestMap
 				&& this.srcToDestMap[feedback.options.dest] == feedback.options.src
 		}

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -1,70 +1,72 @@
 exports.initFeedbacks = function() {
 	const feedbacks = {};
 
-	const foregroundColor = {
-		type: 'colorpicker',
-		label: 'Foreground color',
-		id: 'fg',
-		default: this.rgb(255, 255, 255)
-	};
-
-	const backgroundColorProgram = {
-		type: 'colorpicker',
-		label: 'Background color',
-		id: 'bg',
-		default: this.rgb(255, 0, 0)
-	};
-
 	feedbacks.active_destination = {
-		label: 'Change color for active destination',
-		description: 'When user select a different destination, background color will change',
-		options: [
-			foregroundColor,
-			backgroundColorProgram,
-			{
-				type: 'number',
-				label: 'Destination number',
-				id: 'destination',
-				default: 1
-			}
-		]
-	};
+		type: 'boolean',
+		label: 'Destination change',
+		description: 'When a different destination button is selected in Companion',
+		style: {
+			color: this.rgb(255, 255, 255),
+			bgcolor: this.rgb(255, 0, 0)
+		},
+		options: [{
+			type: 'number',
+			label: 'Destination number',
+			id: 'destination',
+			default: 1
+		}],
+		callback: (feedback) => {
+			return this.selectedDestination == feedback.options.destination
+		}
+	}
 	
 	feedbacks.active_source = {
-		label: 'Change color for active source',
-		description: 'When user select a different source, background color will change',
+		type: 'boolean',
+		label: 'Source change',
+		description: 'When a different source button is selected in Companion',
+		style: {
+			color: this.rgb(255, 255, 255),
+			bgcolor: this.rgb(255, 0, 0)
+		},
+		options: [{
+			type: 'number',
+			label: 'Source number',
+			id: 'source',
+			default: 1
+		}],
+		callback: (feedback) => {
+			return this.selectedSource == feedback.options.source
+		}
+	}
+
+	feedbacks.destination_match = {
+		type: 'boolean',
+		label: 'Source routes to destination',
+		description: 'When the source routes to the destination',
+		style: {
+			color: this.rgb(255, 255, 255),
+			bgcolor: this.rgb(255, 0, 0)
+		},
 		options: [
-			foregroundColor,
-			backgroundColorProgram,
 			{
 				type: 'number',
-				label: 'Source number',
-				id: 'source',
+				label: 'Destination',
+				id: 'dest',
+				default: 1
+			},
+			{
+				type: 'number',
+				label: 'Source',
+				id: 'src',
 				default: 1
 			}
-		]
-	};
+		],
+		callback: (feedback) => {
+			console.log(this.srcToDestMap)
+			return feedback.options.dest in this.srcToDestMap
+				&& this.srcToDestMap[feedback.options.dest] == feedback.options.src
+		}
+	}
 
-	return feedbacks;
-
+	this.setFeedbackDefinitions(feedbacks)
 }
-
-exports.executeFeedback = function (feedback, bank) {
-	if(feedback.type === 'active_destination') {
-		if(this.selectedDestination == feedback.options.destination) {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg
-			};
-		}
-	}
-	
-	if(feedback.type === 'active_source') {
-		if(this.selectedSource == feedback.options.source) {
-			return {
-				color: feedback.options.fg,
-				bgcolor: feedback.options.bg
-			};
-		}
-	}
-};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aja-kumo",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol",


### PR DESCRIPTION
This should close #5 and partially fix #3. This will:

- Add variables for what sources destinations are receiving (ie, `destination_1` = `6`)
- Current feedbacks changed to boolean + upgrade script to fix those up
- New feedback that provides live updates from the device.
- Better support for a connection being active (ie, if a device goes offline it'll now attempt to reconnect every five seconds)
- Since there's no easy way to tell how many in/out is supported by a Kumo, I've gone with the minimum defaults (16 ins to 4 outs). These can be updated in the device config.
- Also tested remote Salvo recalls and updates are sent back on updates.

The `wait_for_config_events` is designed to be called sequentially and the Kumo keeps the http connection open for ~500ms-1s. If there are any updates to a route, it sends and closes the http connection. Additional features may be able to be added later.

Tested on a 64x64 Kumo.