### PR TITLE
Fixes occasional connection issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ class AjaKumoInstance extends InstanceBase {
 			this.watchForNewEvents()
 		})
 		.catch(e => {
-			this.log('error', `Error with new event ${e.message}`)
+			this.log('error', `Error with new event: ${e.message}, will attempt to reconnect...`)
+			// Attempt to reconnect since things could now be out of sync with the device
+			this.disconnect(true)
 		})
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aja-kumo",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Sometimes, device sends 417 status code, which is an error, and then, since watchForNewEvents wasn't called, the connection doesn't update until reconnected. This will cause the connection to reconnect immediately.