### PR TITLE
Fix line number and src number swapped in variable update

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,13 +78,13 @@ class AjaKumoInstance extends InstanceBase {
 									break
 								case '1':
 								case '2':
-									this.setSrcDestName('dest_name', { line: dest_update[1], num: param }, x.str_value)
+									this.setSrcDestName('dest_name', { num: dest_update[1], line: param }, x.str_value)
 									break
 							}
 						}
 						if (src_update !== null) {
 							param = x.param_id.split('_').pop()
-							this.setSrcDestName('src_name', { line: src_update[1], num: param }, x.str_value)
+							this.setSrcDestName('src_name', { num: src_update[1], line: param }, x.str_value)
 						}
 						if (salvo_update !== null) {
 							this.setSalvoName(salvo_update[1], x.str_value.name)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aja-kumo",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Fixes a regression with the variable update when a source/destination name is updated.

Tested on an AJA KUMO 3232